### PR TITLE
Fix string offset access syntax with curly braces

### DIFF
--- a/moregreetings.civix.php
+++ b/moregreetings.civix.php
@@ -243,7 +243,7 @@ function _moregreetings_civix_find_files($dir, $pattern) {
     if ($dh = opendir($subdir)) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
+        if ($entry[0] == '.') {
         }
         elseif (is_dir($path)) {
           $todos[] = $path;


### PR DESCRIPTION
Using {} for array or string offsets is deprecated in PHP 7.4.

I know this file is generated by civix, but this issue is fixed in civix already (totten/civix#177).
If a newer version of civix (not sure which was the first, v21.04.1 is OK) will be used when generating new code, this will be solved.

Until that this patch fixes this issue, so it could be compatible with PHP 7.4.