### PR TITLE
Avoid calling original error handler with NULL reference

### DIFF
--- a/CRM/Moregreetings/Form/Settings.php
+++ b/CRM/Moregreetings/Form/Settings.php
@@ -190,17 +190,20 @@ class CRM_Moregreetings_Form_Settings extends CRM_Core_Form {
    * @throws \ErrorException
    */
   public static function smartyErrorHandler($errNo, $errStr, $errFile, $errLine, $errContext = []) {
+    
     // Call the original error handler with the original error parameters. This
     // makes sure the error still gets printed or logged or whatever the
     // original error handler is supposed to do with it.
-    call_user_func(
-      static::$_original_error_handler,
-      $errNo,
-      $errStr,
-      $errFile,
-      $errLine,
-      $errContext
-    );
+    if (!empty(static::$_original_error_handler)) {
+      call_user_func(
+        static::$_original_error_handler,
+        $errNo,
+        $errStr,
+        $errFile,
+        $errLine,
+        $errContext
+      );
+    }
 
     // Restore the original error handler for subsequent error handling.
     restore_error_handler();

--- a/CRM/Moregreetings/Form/Settings.php
+++ b/CRM/Moregreetings/Form/Settings.php
@@ -194,7 +194,7 @@ class CRM_Moregreetings_Form_Settings extends CRM_Core_Form {
     // Call the original error handler with the original error parameters. This
     // makes sure the error still gets printed or logged or whatever the
     // original error handler is supposed to do with it.
-    if (!empty(static::$_original_error_handler)) {
+    if (is_callable(static::$_original_error_handler)) {
       call_user_func(
         static::$_original_error_handler,
         $errNo,


### PR DESCRIPTION
Hi,

first of all, thanks for your helpful extension. We needed to make two small adjustments to get it running smoothly with PHP 8.1. I see that you already made `$errContext` an optional parameter after the last release.

Apart from that, in our development environment (based on the official wordpress docker image and caddy) `set_error_handler` returns `NULL` which is the reason why calling `call_user_func` throws an exception.

I just wanted to provide our small fix for this issue. I don't know if it has any value for you...

We are using PHP 8.1, WordPress 6.1.1 and CiviCRM 5.59 btw.

Greetings
Valentin