### PR TITLE
Do not replace error handler twice, avoiding infinite loops

### DIFF
--- a/CRM/Moregreetings/Form/Settings.php
+++ b/CRM/Moregreetings/Form/Settings.php
@@ -159,7 +159,9 @@ class CRM_Moregreetings_Form_Settings extends CRM_Core_Form {
       // fetch those, replace the current error handler with a custom one, which
       // will throw an exception, that will be caught here. Store as a static
       // class member in order to access it within the custom error handler.
-      static::$_original_error_handler = set_error_handler(array(get_class(), 'smartyErrorHandler'));
+      if (!isset(static::$_original_error_handler)) {
+        static::$_original_error_handler = set_error_handler(array(get_class(), 'smartyErrorHandler'));
+      }
 
       // Try the rendering.
       try {
@@ -204,6 +206,7 @@ class CRM_Moregreetings_Form_Settings extends CRM_Core_Form {
 
     // Restore the original error handler for subsequent error handling.
     restore_error_handler();
+    static::$_original_error_handler = NULL;
 
     if (strpos($errStr, 'Smarty error:') === 0) {
       throw new ErrorException(

--- a/CRM/Moregreetings/Form/Settings.php
+++ b/CRM/Moregreetings/Form/Settings.php
@@ -195,14 +195,16 @@ class CRM_Moregreetings_Form_Settings extends CRM_Core_Form {
     // Call the original error handler with the original error parameters. This
     // makes sure the error still gets printed or logged or whatever the
     // original error handler is supposed to do with it.
-    call_user_func(
-      static::$_original_error_handler,
-      $errNo,
-      $errStr,
-      $errFile,
-      $errLine,
-      $errContext
-    );
+    if (is_callable(static::$_original_error_handler)) {
+      call_user_func(
+        static::$_original_error_handler,
+        $errNo,
+        $errStr,
+        $errFile,
+        $errLine,
+        $errContext
+      );
+    }
 
     // Restore the original error handler for subsequent error handling.
     restore_error_handler();


### PR DESCRIPTION
Fixes #37.

The extension replaces the error handler to catch *Smarty* errors while validating the settings form (i.e. the actual greeting formulas). When the code replacing the error handler was called twice, the *original* error handler will be lost and the extension can not restore it. In the case of an error (which seems to be a deprecation warning being handled by the error handler), this leads to an infinite loop into our error handler.

This PR guards the error handler replacement by checking whether the replacement has already been done. Also, this clears the static class member which is being used for keeping track of the original error handler when the extension restores it.