### PR TITLE
Load contact fields used in templates via APIv4

### DIFF
--- a/CRM/Moregreetings/Job.php
+++ b/CRM/Moregreetings/Job.php
@@ -15,6 +15,8 @@
 | written permission from the original author(s).        |
 +--------------------------------------------------------*/
 
+use Civi\Api4\Contact;
+
 define('MOREGREETINGS_JOB_SIZE', 250);
 /**
  * Runner Job to apply the current templates to all contacts
@@ -55,13 +57,14 @@ class CRM_Moregreetings_Job {
     // load contacts
     // remark: if you change these parameters, see if you also want to adjust
     //  CRM_Moregreetings_Renderer::updateMoreGreetings and CRM_Moregreetings_Renderer::updateMoreGreetingsForContacts
-    $contacts = civicrm_api3('Contact', 'get', array(
-      'id'           => array('IN' => $contact_ids),
-      'return'       => $used_fields,
-      'option.limit' => 0));
+    $contacts = Contact::get(FALSE)
+      ->setSelect($used_fields)
+      ->addSelect('id')
+      ->addWhere('id', 'IN', $contact_ids)
+      ->execute();
 
     // apply
-    foreach ($contacts['values'] as $contact) {
+    foreach ($contacts as $contact) {
       CRM_Moregreetings_Renderer::updateMoreGreetings($contact['id'], $contact);
     }
 

--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@
 ## Documentation
 - EN: https://docs.civicrm.org/moregreetings/en/latest (automatic publishing)
 - DE: https://docs.civicrm.org/moregreetings/de/latest (automatic publishing)
+
+## Known Issues
+
+With recent CiviCRM versions APIv3 doesn't return some fields for contacts like
+`email_greeting_display` which might lead to empty placeholders. This is
+resolved in version 1.2-beta3 or later of this extension.


### PR DESCRIPTION
Contact fields like `email_greeting_display` aren't returned via APIv3, anymore.

systopia-reference: 24737