### PR TITLE
Replace deprecated usage of `CRM_Core_BAO_Setting`

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,0 +1,42 @@
+name: PHP_CodeSniffer
+
+on:
+  pull_request:
+    paths:
+      - '**.php'
+      - tools/phpcs/composer.json
+      - phpcs.xml.dist
+
+jobs:
+  phpcs:
+    runs-on: ubuntu-latest
+    name: PHP_CodeSniffer
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: 8.3
+        coverage: none
+        tools: cs2pr
+      env:
+        fail-fast: true
+
+    - name: Get composer cache directory
+      id: composer-cache
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+    - name: Cache dependencies
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('tools/phpcs/composer.json') }}
+        restore-keys: ${{ runner.os }}-composer-
+
+    - name: Install dependencies
+      run: composer composer-phpcs -- update --no-progress --prefer-dist
+
+    - name: Run PHP_CodeSniffer
+      run: composer phpcs -- -q --report=checkstyle | cs2pr

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,52 @@
+name: PHPStan
+
+on:
+  pull_request:
+    paths:
+      - '**.php'
+      - composer.json
+      - tools/phpstan/composer.json
+      - ci/composer.json
+      - phpstan.ci.neon
+      - phpstan.neon.dist
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['7.4', '8.0', '8.3']
+        prefer: ['prefer-stable', 'prefer-lowest']
+    name: PHPStan with PHP ${{ matrix.php-versions }} ${{ matrix.prefer }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+        coverage: none
+      env:
+        fail-fast: true
+
+    - name: Get composer cache directory
+      id: composer-cache
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+    - name: Cache dependencies
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ matrix.prefer }}-${{ hashFiles('**/composer.json') }}
+        restore-keys: ${{ runner.os }}-composer-${{ matrix.prefer }}-
+
+    - name: Install dependencies
+      run: |
+        composer update --no-progress --prefer-dist --${{ matrix.prefer }} --optimize-autoloader --ignore-platform-req=ext-gd &&
+        composer composer-phpunit -- update --no-progress --prefer-dist &&
+        composer composer-phpstan -- update --no-progress --prefer-dist --optimize-autoloader &&
+        composer --working-dir=ci update --no-progress --prefer-dist --${{ matrix.prefer }} --optimize-autoloader --ignore-platform-req=ext-gd
+
+    - name: Run PHPStan
+      run: composer phpstan -- analyse -c phpstan.ci.neon

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,40 @@
+name: PHPUnit
+
+on:
+  pull_request:
+    paths:
+      - '**.php'
+      - composer.json
+      - tools/phpunit/composer.json
+      - phpunit.xml.dist
+
+env:
+  # On github CI machine creating the "/vendor" volume fails otherwise with: read-only file system: unknown
+  BIND_VOLUME_PERMISSIONS: rw
+
+jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # The info.xml says CiviCRM 5.38 is supported. Though running phpunit in
+        # that container fails with:
+        # The file "tests/phpunit/api/v4/services.xml" does not exist (in: "/var/www/html/sites/all/modules/civicrm").
+        # Thus, the least version here is 5.39.
+        civicrm-image-tags: [ '5-drupal', '5.39-drupal-php7.4' ]
+    name: PHPUnit with Docker image michaelmcandrew/civicrm:${{ matrix.civicrm-image-tags }}
+    env:
+      CIVICRM_IMAGE_TAG: ${{ matrix.civicrm-image-tags }}
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Pull images
+      run: docker compose -f tests/docker-compose.yml pull --quiet
+    - name: Start containers
+      run: docker compose -f tests/docker-compose.yml up -d
+    - name: Prepare environment
+      run: docker compose -f tests/docker-compose.yml exec civicrm sites/default/files/civicrm/ext/de.systopia.moregreetings/tests/docker-prepare.sh
+    - name: Run PHPUnit
+      run: docker compose -f tests/docker-compose.yml exec civicrm sites/default/files/civicrm/ext/de.systopia.moregreetings/tests/docker-phpunit.sh
+    - name: Remove containers
+      run: docker compose -f tests/docker-compose.yml down -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/.phpcs.cache
+/.phpunit.result.cache
+/.phpstan/
+/phpstan.neon
+/tools/*/vendor/
+/tools/*/composer.lock

--- a/CRM/Moregreetings/Config.php
+++ b/CRM/Moregreetings/Config.php
@@ -152,7 +152,7 @@ class CRM_Moregreetings_Config {
     $job = self::getAllGreetingsJob();
 
     // start from zero:
-    CRM_Core_BAO_Setting::setItem('0', 'moregreetings', 'moregreetings_job_status');
+    Civi::settings()->set('moregreetings_job_status', '0');
 
     // enable cronjob
     if (!$job['is_active']) {

--- a/CRM/Moregreetings/Form/Settings.php
+++ b/CRM/Moregreetings/Form/Settings.php
@@ -93,7 +93,7 @@ class CRM_Moregreetings_Form_Settings extends CRM_Core_Form {
    * set the default (=current) values in the form
    */
   public function setDefaultValues() {
-    $values = CRM_Core_BAO_Setting::getItem('moregreetings', 'moregreetings_templates');
+    $values = Civi::settings()->get('moregreetings_templates');
     if (!is_array($values)) {
       $values = array();
     }
@@ -109,7 +109,7 @@ class CRM_Moregreetings_Form_Settings extends CRM_Core_Form {
     $values = $this->exportValues();
 
     // first: update the greetings
-    $old_greetings = CRM_Core_BAO_Setting::getItem('moregreetings', 'moregreetings_templates');
+    $old_greetings = Civi::settings()->get('moregreetings_templates');
     $greetings_changed = FALSE;
     for ($i = 1; $i <= self::getNumberOfGreetings(); ++$i) {
       if (isset($values["greeting_smarty_{$i}"])) {
@@ -123,7 +123,7 @@ class CRM_Moregreetings_Form_Settings extends CRM_Core_Form {
         $greetings_changed = TRUE;
       }
     }
-    CRM_Core_BAO_Setting::setItem($values_array, 'moregreetings', 'moregreetings_templates');
+    Civi::settings()->set('moregreetings_templates', $values_array);
 
     // then: adjust the greeting count
     if ($values['greeting_count'] != self::getNumberOfGreetings()) {

--- a/CRM/Moregreetings/Job.php
+++ b/CRM/Moregreetings/Job.php
@@ -51,7 +51,7 @@ class CRM_Moregreetings_Job {
     }
 
     // determine the fields to load
-    $templates = CRM_Core_BAO_Setting::getItem('moregreetings', 'moregreetings_templates');
+    $templates = Civi::settings()->get('moregreetings_templates');
     $used_fields = CRM_Moregreetings_Renderer::getUsedContactFields($templates);
 
     // load contacts

--- a/CRM/Moregreetings/Renderer.php
+++ b/CRM/Moregreetings/Renderer.php
@@ -36,7 +36,7 @@ class CRM_Moregreetings_Renderer {
     }
 
     // load the templates
-    $templates = CRM_Core_BAO_Setting::getItem('moregreetings', 'moregreetings_templates');
+    $templates = Civi::settings()->get('moregreetings_templates');
     if (!is_array($templates)) {
       return;
     }
@@ -95,7 +95,7 @@ class CRM_Moregreetings_Renderer {
    * @return int last contact ID processed, 0 if none
    */
   public static function updateMoreGreetingsForContacts($from_id, $max_count): int {
-    $templates = CRM_Core_BAO_Setting::getItem('moregreetings', 'moregreetings_templates');
+    $templates = Civi::settings()->get('moregreetings_templates');
 
     // remark: if you change these parameters, see if you also want to adjust
     //  CRM_Moregreetings_Job::run and CRM_Moregreetings_Renderer::updateMoreGreetings

--- a/CRM/Xdedupe/Resolver/MoreGreetingsSubscriber.php
+++ b/CRM/Xdedupe/Resolver/MoreGreetingsSubscriber.php
@@ -27,7 +27,7 @@ class CRM_Xdedupe_Resolver_MoreGreetingsSubscriber implements EventSubscriberInt
   /**
    * Subscribe to the list events, so we can plug the built-in ones
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
         'civi.xdedupe.resolvers' => ['addBuiltinResolvers', Events::W_MIDDLE],
     ];

--- a/api/v3/Job/UpdateMoregreetings.php
+++ b/api/v3/Job/UpdateMoregreetings.php
@@ -41,7 +41,7 @@ function civicrm_api3_job_update_moregreetings($params) {
   }
 
   // store last processed ID
-  Civi::settings()->set('moregreetings_job_status', (string)$last_id);
+  Civi::settings()->set('moregreetings_job_status', (string) $last_id);
 
   if ($last_id == 0) {
     // we're done!

--- a/api/v3/Job/UpdateMoregreetings.php
+++ b/api/v3/Job/UpdateMoregreetings.php
@@ -19,14 +19,14 @@
  * Cron Job to update the more-greetings for all contacts
  */
 function civicrm_api3_job_update_moregreetings($params) {
-  $last_id = CRM_Core_BAO_Setting::getItem('moregreetings', 'moregreetings_job_status');
+  $last_id = Civi::settings()->get('moregreetings_job_status');
   if ($last_id == 'busy') {
     // there's another job running
     return civicrm_api3_create_success(ts("Job already running", array('domain' => 'de.systopia.moregreetings')));
   }
 
   // ok, let's go
-  CRM_Core_BAO_Setting::setItem('busy', 'moregreetings', 'moregreetings_job_status');
+  Civi::settings()->set('moregreetings_job_status', 'busy');
   $start_time = microtime(TRUE);
 
   // run the renderer on blocks of contacts until the time runs out
@@ -41,7 +41,7 @@ function civicrm_api3_job_update_moregreetings($params) {
   }
 
   // store last processed ID
-  CRM_Core_BAO_Setting::setItem((string)$last_id, 'moregreetings', 'moregreetings_job_status');
+  Civi::settings()->set('moregreetings_job_status', (string)$last_id);
 
   if ($last_id == 0) {
     // we're done!

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,2 @@
+The dependencies specified in composer.json of this directory are required to
+run phpstan in CI.

--- a/ci/composer.json
+++ b/ci/composer.json
@@ -1,0 +1,14 @@
+{
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "civicrm/composer-compile-plugin": false,
+            "civicrm/composer-downloads-plugin": true,
+            "cweagans/composer-patches": true
+        }
+    },
+    "require": {
+        "civicrm/civicrm-core": "^5.38"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,44 @@
+{
+    "name": "systopia/de.systopia.moregreetings",
+    "type": "civicrm-ext",
+    "license": "AGPL-3.0-or-later",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "config": {
+        "sort-packages": true
+    },
+    "require": {},
+    "scripts": {
+        "composer-phpcs": [
+            "@composer --working-dir=tools/phpcs"
+        ],
+        "composer-phpstan": [
+            "@composer --working-dir=tools/phpstan"
+        ],
+        "composer-phpunit": [
+            "@composer --working-dir=tools/phpunit"
+        ],
+        "composer-tools": [
+            "@composer-phpcs",
+            "@composer-phpstan",
+            "@composer-phpunit"
+        ],
+        "phpcs": [
+            "@php tools/phpcs/vendor/bin/phpcs"
+        ],
+        "phpcbf": [
+            "@php tools/phpcs/vendor/bin/phpcbf"
+        ],
+        "phpstan": [
+            "@php tools/phpstan/vendor/bin/phpstan"
+        ],
+        "phpunit": [
+            "@php tools/phpunit/vendor/bin/simple-phpunit --coverage-text"
+        ],
+        "test": [
+            "@phpcs",
+            "@phpstan",
+            "@phpunit"
+        ]
+    }
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="CiviCRM - PHPStan"
+         xsi:noNamespaceSchemaLocation="tools/phpcs/vendor/squizlabs/php_codesniffer/phpcs.xsd">
+    <description>CiviCRM coding standard with support for PHPStan type hints and some additional rules</description>
+
+    <!-- TODO: Commented paths should be commented in. -->
+    <!--<file>api</file>-->
+    <!--<file>CRM</file>-->
+    <file>tests</file>
+    <!--<file>moregreetings.php</file>-->
+
+    <arg name="extensions" value="php"/>
+    <arg name="cache" value=".phpcs.cache"/>
+    <arg name="colors"/>
+    <arg value="sp"/>
+
+    <!-- Exit with code 0 if warnings, but no error occurred -->
+    <config name="ignore_warnings_on_exit" value="true"/>
+
+    <rule ref="tools/phpcs/vendor/drupal/coder/coder_sniffer/Drupal">
+        <!-- Conflicts with PHPStan type hints -->
+        <exclude name="Drupal.Commenting.VariableComment.IncorrectVarType"/>
+        <exclude name="Drupal.Commenting.FunctionComment.ParamTypeSpaces"/>
+        <exclude name="Drupal.Commenting.VariableComment.MissingVar"/>
+
+        <!-- Don't enforce phpdoc type hint because it (might) only duplicate a PHP type hint -->
+        <exclude name="Drupal.Commenting.FunctionComment.ParamMissingDefinition"/>
+
+        <!-- False positive when license header is set and variable has no comment -->
+        <exclude name="Drupal.Commenting.VariableComment.WrongStyle"/>
+
+        <exclude name="Drupal.Commenting.VariableComment.MissingVar"/>
+    </rule>
+
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+    <rule ref="Generic.CodeAnalysis.EmptyStatement">
+        <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedCatch"/>
+    </rule>
+    <rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall"/>
+    <rule ref="Generic.Files.OneClassPerFile"/>
+    <rule ref="Generic.Files.OneInterfacePerFile"/>
+    <rule ref="Generic.Files.OneObjectStructurePerFile"/>
+    <rule ref="Generic.Files.OneTraitPerFile"/>
+    <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
+    <rule ref="Generic.Metrics.CyclomaticComplexity"/>
+    <rule ref="Generic.Metrics.NestingLevel"/>
+    <rule ref="Generic.NamingConventions.AbstractClassNamePrefix"/>
+    <rule ref="Generic.NamingConventions.InterfaceNameSuffix"/>
+    <rule ref="Generic.NamingConventions.TraitNameSuffix"/>
+    <rule ref="Generic.PHP.RequireStrictTypes"/>
+    <rule ref="PSR1.Files.SideEffects"/>
+    <rule ref="PSR12.Classes.ClassInstantiation"/>
+    <rule ref="PSR12.Properties.ConstantVisibility"/>
+    <rule ref="Squiz.PHP.CommentedOutCode"/>
+    <rule ref="Squiz.PHP.GlobalKeyword"/>
+    <rule ref="Squiz.Strings.DoubleQuoteUsage">
+        <exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar"/>
+    </rule>
+
+    <!-- Lines can be 120 chars long, but never show errors -->
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="120"/>
+            <property name="absoluteLineLimit" value="0"/>
+        </properties>
+    </rule>
+
+    <!-- Ban some functions -->
+    <rule ref="Generic.PHP.ForbiddenFunctions">
+        <properties>
+            <property name="forbiddenFunctions" type="array">
+                <element key="sizeof" value="count"/>
+                <element key="delete" value="unset"/>
+                <element key="print" value="echo"/>
+                <element key="is_null" value="null"/>
+                <element key="create_function" value="null"/>
+            </property>
+        </properties>
+    </rule>
+</ruleset>

--- a/phpstan.ci.neon
+++ b/phpstan.ci.neon
@@ -1,0 +1,15 @@
+includes:
+	- phpstan.neon.dist
+
+parameters:
+	scanDirectories:
+		- ci/vendor/civicrm/civicrm-core/api/
+		- ci/vendor/civicrm/civicrm-core/CRM/
+	bootstrapFiles:
+		- ci/vendor/autoload.php
+	# Because we test with different versions in CI we have unmatched errors
+	reportUnmatchedIgnoredErrors: false
+	ignoreErrors:
+		# Errors we get when using "prefer-lowest"
+		- '#^Method Civi\\Moregreetings\\Fixtures\\ContactFixture::addIndividual\(\) has CRM_Core_Exception in PHPDoc @throws tag but it.s not thrown.$#'
+		- '#::getSubscribedEvents\(\) return type has no value type specified in iterable type array.$#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,37 @@
+parameters:
+	paths:
+		# TODO: Commented paths should be commented in. Maybe the level should be reduced initially.
+		#- api
+		#- CRM
+		- tests
+		#- moregreetings.php
+	excludePaths:
+		analyse:
+			- tests/phpunit/bootstrap.php
+	scanFiles:
+		- moregreetings.civix.php
+		- tools/phpunit/vendor/bin/.phpunit/phpunit/src/Framework/TestCase.php
+	scanDirectories:
+		- CRM
+		- tools/phpunit/vendor/bin/.phpunit/phpunit/src/Framework
+	bootstrapFiles:
+		- tools/phpunit/vendor/bin/.phpunit/phpunit/vendor/autoload.php
+		- phpstanBootstrap.php
+	level: 9
+	universalObjectCratesClasses:
+		- Civi\Core\Event\GenericHookEvent
+	checkTooWideReturnTypesInProtectedAndPublicMethods: true
+	checkUninitializedProperties: true
+	checkMissingCallableSignature: true
+	treatPhpDocTypesAsCertain: false
+	exceptions:
+		check:
+			missingCheckedExceptionInThrows: true
+			tooWideThrowType: true
+		checkedExceptionClasses:
+			- \Webmozart\Assert\InvalidArgumentException
+		implicitThrows: false
+	ignoreErrors:
+		# Note paths are prefixed with ""*/" to wirk with inspections in PHPStorm because of:
+		# https://youtrack.jetbrains.com/issue/WI-63891/PHPStan-ignoreErrors-configuration-isnt-working-with-inspections
+	tmpDir: .phpstan

--- a/phpstan.neon.template
+++ b/phpstan.neon.template
@@ -1,0 +1,12 @@
+# Copy this file to phpstan.neon and replace {VENDOR_DIR} with the appropriate
+# paths.
+
+includes:
+	- phpstan.neon.dist
+
+parameters:
+	scanDirectories:
+		- {VENDOR_DIR}/civicrm/civicrm-core/api/
+		- {VENDOR_DIR}/civicrm/civicrm-core/CRM/
+	bootstrapFiles:
+		- {VENDOR_DIR}/autoload.php

--- a/phpstanBootstrap.php
+++ b/phpstanBootstrap.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * Copyright (C) 2022 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+  require_once __DIR__ . '/vendor/autoload.php';
+}
+
+// phpcs:disable Drupal.Commenting.DocComment.ContentAfterOpen
+/** @var \PHPStan\DependencyInjection\Container $container */
+/** @phpstan-var array<string> $bootstrapFiles */
+$bootstrapFiles = $container->getParameter('bootstrapFiles');
+foreach ($bootstrapFiles as $bootstrapFile) {
+  if (str_ends_with($bootstrapFile, 'vendor/autoload.php')) {
+    $vendorDir = dirname($bootstrapFile);
+    $civiCrmVendorDir = $vendorDir . '/civicrm';
+    $civiCrmCoreDir = $civiCrmVendorDir . '/civicrm-core';
+    if (file_exists($civiCrmCoreDir)) {
+      set_include_path(get_include_path()
+        . PATH_SEPARATOR . $civiCrmCoreDir
+        . PATH_SEPARATOR . $civiCrmVendorDir . '/civicrm-packages'
+      );
+      // $bootstrapFile might not be included, yet. It is required for the
+      // following require_once, though.
+      require_once $bootstrapFile;
+      // Prevent error "Class 'CRM_Core_Exception' not found in file".
+      require_once $civiCrmCoreDir . '/CRM/Core/Exception.php';
+
+      break;
+    }
+  }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
+         colors="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         forceCoversAnnotation="true"
+         bootstrap="tests/phpunit/bootstrap.php">
+
+  <php>
+    <ini name="error_reporting" value="-1" />
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0&amp;baselineFile=./tests/ignored-deprecations.json"/>
+  </php>
+
+  <testsuites>
+    <testsuite name="My Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">api</directory>
+      <directory suffix=".php">CRM</directory>
+      <directory suffix=".php">Civi</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3"
+services:
+  civicrm:
+    image: michaelmcandrew/civicrm:${CIVICRM_IMAGE_TAG:-5-drupal}
+    environment:
+      - PROJECT_NAME=test
+      - BASE_URL=http://localhost
+      - CIVICRM_DB_NAME=test
+      - CIVICRM_DB_USER=root
+      - CIVICRM_DB_PASS=secret
+      - CIVICRM_DB_HOST=mysql
+      - CIVICRM_DB_PORT=3306
+      - CIVICRM_SITE_KEY=test
+      - DRUPAL_DB_NAME=test
+      - DRUPAL_DB_USER=root
+      - DRUPAL_DB_PASS=secret
+      - DRUPAL_DB_HOST=mysql
+      - DRUPAL_DB_PORT=3306
+      - PHP_DATE_TIMEZONE=UTC
+      - DEBUG=ON
+      - SMTP_HOST=localhost
+      - SMTP_MAILDOMAIN=example.org
+    volumes:
+      - ../:/var/www/html/sites/default/files/civicrm/ext/de.systopia.moregreetings:${BIND_VOLUME_PERMISSIONS:-ro}
+      - /var/www/html/sites/default/files/civicrm/ext/de.systopia.moregreetings/vendor
+      - /var/www/html/sites/default/files/civicrm/ext/de.systopia.moregreetings/tools/phpunit/vendor
+    # Don't start Apache HTTP Server, but keep container running
+    command: ["tail", "-f", "/dev/null"]
+    stop_signal: SIGKILL
+  mysql:
+    image: mariadb
+    environment:
+      MARIADB_ROOT_PASSWORD: secret
+      MARIADB_DATABASE: test

--- a/tests/docker-phpunit.sh
+++ b/tests/docker-phpunit.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -eu -o pipefail
+
+SCRIPT_DIR=$(realpath "$(dirname "$0")")
+EXT_DIR=$(dirname "$SCRIPT_DIR")
+
+cd "$EXT_DIR"
+if [ ! -e tools/phpunit/vendor/bin ]; then
+  "$SCRIPT_DIR/docker-prepare.sh"
+fi
+
+export XDEBUG_MODE=coverage
+# TODO: Remove when not needed, anymore.
+# In Docker container with CiviCRM 5.5? all deprecations are reported as direct
+# deprecations so "disabling" check of deprecation count is necessary for the
+# tests to pass (if baselineFile does not contain all deprecations).
+export SYMFONY_DEPRECATIONS_HELPER="max[total]=99999&baselineFile=./tests/ignored-deprecations.json"
+
+composer phpunit -- --cache-result-file=/tmp/.phpunit.result.cache "$@"

--- a/tests/docker-prepare.sh
+++ b/tests/docker-prepare.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -eu -o pipefail
+
+EXT_DIR=$(dirname "$(dirname "$(realpath "$0")")")
+EXT_NAME=$(basename "$EXT_DIR")
+
+i=0
+while ! mysql -h "$CIVICRM_DB_HOST" -P "$CIVICRM_DB_PORT" -u "$CIVICRM_DB_USER" --password="$CIVICRM_DB_PASS" -e 'SELECT 1;' >/dev/null 2>&1; do
+  i=$((i+1))
+  if [ $i -gt 10 ]; then
+    echo "Failed to connect to database" >&2
+    exit 1
+  fi
+
+  echo -n .
+  sleep 1
+done
+
+echo
+
+export XDEBUG_MODE=off
+if mysql -h "$CIVICRM_DB_HOST" -P "$CIVICRM_DB_PORT" -u "$CIVICRM_DB_USER" --password="$CIVICRM_DB_PASS" "$CIVICRM_DB_NAME" -e 'SELECT 1 FROM civicrm_setting LIMIT 1;' >/dev/null 2>&1; then
+  cv flush
+else
+  # For headless tests it is required that CIVICRM_UF is defined using the corresponding env variable.
+  sed -E "s/define\('CIVICRM_UF', '([^']+)'\);/define('CIVICRM_UF', getenv('CIVICRM_UF') ?: '\1');/g" \
+    -i /var/www/html/sites/default/civicrm.settings.php
+  civicrm-docker-install
+
+  # Avoid this error:
+  # The autoloader expected class "Civi\ActionSchedule\Mapping" to be defined in
+  # file "[...]/Civi/ActionSchedule/Mapping.php". The file was found but the
+  # class was not in it, the class name or namespace probably has a typo.
+  rm -f /var/www/html/sites/all/modules/civicrm/Civi/ActionSchedule/Mapping.php
+
+  # For headless tests these files need to exist.
+  touch /var/www/html/sites/all/modules/civicrm/sql/test_data.mysql
+  touch /var/www/html/sites/all/modules/civicrm/sql/test_data_second_domain.mysql
+
+  cv ext:enable "$EXT_NAME"
+fi
+
+cd "$EXT_DIR"
+composer update --no-progress --prefer-dist --optimize-autoloader --no-dev
+composer composer-phpunit -- update --no-progress --prefer-dist

--- a/tests/ignored-deprecations.json
+++ b/tests/ignored-deprecations.json
@@ -1,0 +1,1317 @@
+[
+    {
+        "location": "Civi\\Test\\CiviTestListenerPHPUnit7",
+        "message": "The \"Civi\\Test\\CiviTestListenerPHPUnit7\" class implements \"PHPUnit\\Framework\\TestListener\" that is deprecated.",
+        "count": 1
+    },
+    {
+        "location": "Civi\\Test\\CiviTestListenerPHPUnit7",
+        "message": "The \"Civi\\Test\\CiviTestListenerPHPUnit7\" class uses \"PHPUnit\\Framework\\TestListenerDefaultImplementation\" that is deprecated The `TestListener` interface is deprecated.",
+        "count": 1
+    },
+    {
+        "location": "Civi\\Test\\CiviTestListener",
+        "message": "The \"Civi\\Test\\CiviTestListenerPHPUnit7\" class implements \"PHPUnit\\Framework\\TestListener\" that is deprecated.",
+        "count": 1
+    },
+    {
+        "location": "Civi\\Test\\CiviTestListener",
+        "message": "The \"Civi\\Test\\CiviTestListenerPHPUnit7\" class uses \"PHPUnit\\Framework\\TestListenerDefaultImplementation\" that is deprecated The `TestListener` interface is deprecated.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_System_UnitTests",
+        "message": "The \"CRM_Utils_System_Base::isLoaded()\" method is considered internal. It may change without further notice. You should not extend it from \"CRM_Utils_System_UnitTests\".",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_System_UnitTests",
+        "message": "Method \"CRM_Utils_System_Base::authenticate()\" might add \"array|bool\" as a native return type declaration in the future. Do the same in child class \"CRM_Utils_System_UnitTests\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_System_UnitTests",
+        "message": "Method \"CRM_Utils_System_Base::cmsRootPath()\" might add \"?string\" as a native return type declaration in the future. Do the same in child class \"CRM_Utils_System_UnitTests\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_System_UnitTests",
+        "message": "Method \"CRM_Utils_System_Base::postURL()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Utils_System_UnitTests\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_System_UnitTests",
+        "message": "Method \"CRM_Utils_System_Base::url()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Utils_System_UnitTests\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_System_UnitTests",
+        "message": "Method \"CRM_Utils_System_Base::getLoginURL()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Utils_System_UnitTests\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_Cache_SqlGroup",
+        "message": "Method \"CRM_Utils_Cache_Interface::has()\" might add \"bool\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_Cache_SqlGroup\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_Cache_SqlGroup",
+        "message": "Method \"CRM_Utils_Cache_Interface::flush()\" might add \"bool\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_Cache_SqlGroup\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_Cache_SqlGroup",
+        "message": "Method \"CRM_Utils_Cache_Interface::clear()\" might add \"bool\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_Cache_SqlGroup\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Cache",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Cache\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_Cache_CacheWrapper",
+        "message": "Method \"Psr\\SimpleCache\\CacheInterface::getMultiple()\" might add \"iterable\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_Cache_CacheWrapper\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_Cache_CacheWrapper",
+        "message": "Method \"Psr\\SimpleCache\\CacheInterface::setMultiple()\" might add \"bool\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_Cache_CacheWrapper\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_Cache_CacheWrapper",
+        "message": "Method \"Psr\\SimpleCache\\CacheInterface::deleteMultiple()\" might add \"bool\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_Cache_CacheWrapper\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_Cache_CacheWrapper",
+        "message": "Method \"CRM_Utils_Cache_Interface::set()\" might add \"bool\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_Cache_CacheWrapper\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_Cache_CacheWrapper",
+        "message": "Method \"CRM_Utils_Cache_Interface::get()\" might add \"mixed\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_Cache_CacheWrapper\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_Cache_CacheWrapper",
+        "message": "Method \"CRM_Utils_Cache_Interface::delete()\" might add \"bool\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_Cache_CacheWrapper\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_Cache_CacheWrapper",
+        "message": "Method \"CRM_Utils_Cache_Interface::clear()\" might add \"bool\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_Cache_CacheWrapper\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_Cache_CacheWrapper",
+        "message": "Method \"CRM_Utils_Cache_Interface::has()\" might add \"bool\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_Cache_CacheWrapper\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_Cache_ArrayCache",
+        "message": "Method \"CRM_Utils_Cache_Interface::flush()\" might add \"bool\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_Cache_ArrayCache\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_Cache_ArrayCache",
+        "message": "Method \"CRM_Utils_Cache_Interface::clear()\" might add \"bool\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_Cache_ArrayCache\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_Cache_ArrayCache",
+        "message": "Method \"CRM_Utils_Cache_Interface::has()\" might add \"bool\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_Cache_ArrayCache\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "Civi\\Core\\Compiler\\AutoServiceScannerPass",
+        "message": "Method \"Symfony\\Component\\DependencyInjection\\Compiler\\CompilerPassInterface::process()\" might add \"void\" as a native return type declaration in the future. Do the same in implementation \"Civi\\Core\\Compiler\\AutoServiceScannerPass\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "Civi\\Core\\Compiler\\EventScannerPass",
+        "message": "Method \"Symfony\\Component\\DependencyInjection\\Compiler\\CompilerPassInterface::process()\" might add \"void\" as a native return type declaration in the future. Do the same in implementation \"Civi\\Core\\Compiler\\EventScannerPass\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "Civi\\Core\\Compiler\\SpecProviderPass",
+        "message": "Method \"Symfony\\Component\\DependencyInjection\\Compiler\\CompilerPassInterface::process()\" might add \"void\" as a native return type declaration in the future. Do the same in implementation \"Civi\\Core\\Compiler\\SpecProviderPass\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Extension",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Extension\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_LocationType",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_LocationType\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Managed",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Managed\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Mapping",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Mapping\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_MessageTemplate",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_MessageTemplate\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_OptionGroup",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_OptionGroup\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_PreferencesDate",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_PreferencesDate\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Translation",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Translation\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_PrevNextCache",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_PrevNextCache\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_RecurringEntity",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_RecurringEntity\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_BAO_RecurringEntity",
+        "message": "Method \"Symfony\\Component\\EventDispatcher\\EventSubscriberInterface::getSubscribedEvents()\" might add \"array\" as a native return type declaration in the future. Do the same in implementation \"CRM_Core_BAO_RecurringEntity\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_ACL_DAO_ACL",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_ACL_DAO_ACL\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_ACL_DAO_ACLEntityRole",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_ACL_DAO_ACLEntityRole\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contact_DAO_Contact",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contact_DAO_Contact\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contact_DAO_RelationshipType",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contact_DAO_RelationshipType\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contact_DAO_SavedSearch",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contact_DAO_SavedSearch\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contact_DAO_ContactType",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contact_DAO_ContactType\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Batch_DAO_Batch",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Batch_DAO_Batch\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Batch_BAO_Batch",
+        "message": "The \"CRM_Batch_BAO_Batch::links()\" method will require a new \"array $new_links\" argument in the next major version of its parent class \"DB_DataObject\", not defining it is deprecated.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Batch_DAO_EntityBatch",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Batch_DAO_EntityBatch\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_DAO_MailingComponent",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_DAO_MailingComponent\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_DAO_MailingAB",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_DAO_MailingAB\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_DAO_BouncePattern",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_DAO_BouncePattern\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contribute_DAO_Premium",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contribute_DAO_Premium\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Financial_DAO_FinancialAccount",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Financial_DAO_FinancialAccount\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Financial_DAO_PaymentProcessorType",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Financial_DAO_PaymentProcessorType\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Financial_DAO_FinancialType",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Financial_DAO_FinancialType\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Financial_DAO_EntityFinancialAccount",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Financial_DAO_EntityFinancialAccount\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Financial_DAO_FinancialItem",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Financial_DAO_FinancialItem\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Member_DAO_MembershipStatus",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Member_DAO_MembershipStatus\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Campaign_DAO_Campaign",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Campaign_DAO_Campaign\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Campaign_DAO_Survey",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Campaign_DAO_Survey\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Event_DAO_ParticipantStatusType",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Event_DAO_ParticipantStatusType\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Dedupe_DAO_DedupeRuleGroup",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Dedupe_DAO_DedupeRuleGroup\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Dedupe_DAO_DedupeRule",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Dedupe_DAO_DedupeRule\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Dedupe_DAO_DedupeException",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Dedupe_DAO_DedupeException\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Case_DAO_CaseType",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Case_DAO_CaseType\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Friend_DAO_Friend",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Friend_DAO_Friend\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Pledge_DAO_PledgeBlock",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Pledge_DAO_PledgeBlock\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Queue_DAO_Queue",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Queue_DAO_Queue\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Queue_DAO_QueueItem",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Queue_DAO_QueueItem\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_PCP_DAO_PCP",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_PCP_DAO_PCP\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Cxn_DAO_Cxn",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Cxn_DAO_Cxn\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Country",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Country\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_CustomGroup",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_CustomGroup\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_BAO_CustomGroup",
+        "message": "Method \"CRM_Core_DAO::buildOptions()\" might add \"array|bool\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_BAO_CustomGroup\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_CustomField",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_CustomField\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_BAO_CustomField",
+        "message": "Method \"CRM_Core_DAO::buildOptions()\" might add \"array|bool\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_BAO_CustomField\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Domain",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Domain\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Email",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Email\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_File",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_File\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_IM",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_IM\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Job",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Job\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Log",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Log\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_MailSettings",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_MailSettings\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Navigation",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Navigation\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Note",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Note\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_OptionValue",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_OptionValue\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Phone",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Phone\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Tag",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Tag\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_UFMatch",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_UFMatch\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_UserJob",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_UserJob\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_OpenID",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_OpenID\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Website",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Website\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Setting",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Setting\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_WordReplacement",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_WordReplacement\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_StatusPreference",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_StatusPreference\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contact_DAO_Group",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contact_DAO_Group\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contact_DAO_SubscriptionHistory",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contact_DAO_SubscriptionHistory\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contact_DAO_GroupContactCache",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contact_DAO_GroupContactCache\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contact_DAO_GroupNesting",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contact_DAO_GroupNesting\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contact_DAO_GroupOrganization",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contact_DAO_GroupOrganization\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_Event_DAO_MailingEventSubscribe",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_Event_DAO_MailingEventSubscribe\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_Event_DAO_MailingEventConfirm",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_Event_DAO_MailingEventConfirm\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contribute_DAO_ContributionPage",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contribute_DAO_ContributionPage\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contribute_DAO_Product",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contribute_DAO_Product\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contribute_DAO_Widget",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contribute_DAO_Widget\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Financial_DAO_PaymentProcessor",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Financial_DAO_PaymentProcessor\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_SMS_DAO_SmsProvider",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_SMS_DAO_SmsProvider\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Member_DAO_MembershipType",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Member_DAO_MembershipType\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Member_DAO_MembershipBlock",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Member_DAO_MembershipBlock\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Case_DAO_Case",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Case_DAO_Case\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Case_DAO_CaseContact",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Case_DAO_CaseContact\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Pledge_DAO_Pledge",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Pledge_DAO_Pledge\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Report_DAO_ReportInstance",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Report_DAO_ReportInstance\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Price_DAO_PriceSet",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Price_DAO_PriceSet\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_County",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_County\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Dashboard",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Dashboard\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Discount",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Discount\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_BAO_Discount",
+        "message": "Method \"CRM_Core_DAO::buildOptions()\" might add \"array|bool\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_BAO_Discount\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_EntityTag",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_EntityTag\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_UFGroup",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_UFGroup\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_UFField",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_UFField\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_UFJoin",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_UFJoin\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_ActionSchedule",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_ActionSchedule\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_ActionLog",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_ActionLog\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contact_DAO_DashboardContact",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contact_DAO_DashboardContact\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contact_DAO_Relationship",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contact_DAO_Relationship\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contact_BAO_Relationship",
+        "message": "Method \"CRM_Core_DAO::buildOptions()\" might add \"array|bool\" as a native return type declaration in the future. Do the same in child class \"CRM_Contact_BAO_Relationship\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contact_DAO_RelationshipCache",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contact_DAO_RelationshipCache\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_DAO_Mailing",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_DAO_Mailing\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_DAO_MailingTrackableURL",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_DAO_MailingTrackableURL\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_DAO_MailingJob",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_DAO_MailingJob\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_DAO_MailingRecipients",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_DAO_MailingRecipients\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_DAO_Spool",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_DAO_Spool\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_Event_DAO_MailingEventQueue",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_Event_DAO_MailingEventQueue\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_Event_DAO_MailingEventBounce",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_Event_DAO_MailingEventBounce\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_Event_DAO_MailingEventDelivered",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_Event_DAO_MailingEventDelivered\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_Event_DAO_MailingEventForward",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_Event_DAO_MailingEventForward\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_Event_DAO_MailingEventOpened",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_Event_DAO_MailingEventOpened\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_Event_DAO_MailingEventReply",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_Event_DAO_MailingEventReply\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_Event_DAO_MailingEventTrackableURLOpen",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_Event_DAO_MailingEventTrackableURLOpen\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_Event_DAO_MailingEventUnsubscribe",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_Event_DAO_MailingEventUnsubscribe\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contribute_DAO_ContributionRecur",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contribute_DAO_ContributionRecur\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contribute_BAO_ContributionRecur",
+        "message": "Method \"CRM_Core_DAO::buildOptions()\" might add \"array|bool\" as a native return type declaration in the future. Do the same in child class \"CRM_Contribute_BAO_ContributionRecur\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Financial_DAO_FinancialTrxn",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Financial_DAO_FinancialTrxn\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Member_DAO_Membership",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Member_DAO_Membership\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Member_DAO_MembershipLog",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Member_DAO_MembershipLog\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Activity_DAO_Activity",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Activity_DAO_Activity\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Activity_DAO_ActivityContact",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Activity_DAO_ActivityContact\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Activity_BAO_ActivityContact",
+        "message": "The \"CRM_Activity_BAO_ActivityContact::links()\" method will require a new \"array $new_links\" argument in the next major version of its parent class \"DB_DataObject\", not defining it is deprecated.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Price_DAO_PriceField",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Price_DAO_PriceField\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Price_DAO_PriceFieldValue",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Price_DAO_PriceFieldValue\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_PCP_DAO_PCPBlock",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_PCP_DAO_PCPBlock\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Address",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Address\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contact_DAO_GroupContact",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contact_DAO_GroupContact\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contribute_DAO_Contribution",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contribute_DAO_Contribution\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contribute_DAO_ContributionSoft",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contribute_DAO_ContributionSoft\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Financial_DAO_EntityFinancialTrxn",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Financial_DAO_EntityFinancialTrxn\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Member_DAO_MembershipPayment",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Member_DAO_MembershipPayment\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Event_DAO_Event",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Event_DAO_Event\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Event_DAO_Participant",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Event_DAO_Participant\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Event_DAO_ParticipantPayment",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Event_DAO_ParticipantPayment\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Pledge_DAO_PledgePayment",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Pledge_DAO_PledgePayment\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Price_DAO_LineItem",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Price_DAO_LineItem\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Activity_ActionMapping",
+        "message": "Method \"Civi\\ActionSchedule\\MappingInterface::getId()\" might add \"string|int\" as a native return type declaration in the future. Do the same in implementation \"CRM_Activity_ActionMapping\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "Civi\\Token\\AbstractTokenSubscriber",
+        "message": "Method \"Symfony\\Component\\EventDispatcher\\EventSubscriberInterface::getSubscribedEvents()\" might add \"array\" as a native return type declaration in the future. Do the same in implementation \"Civi\\Token\\AbstractTokenSubscriber\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Activity_Tokens",
+        "message": "Method \"CRM_Core_EntityTokens::getActiveTokens()\" might add \"mixed\" as a native return type declaration in the future. Do the same in child class \"CRM_Activity_Tokens\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Campaign_Info",
+        "message": "Method \"CRM_Core_Component_Info::getActivityTypes()\" might add \"?array\" as a native return type declaration in the future. Do the same in child class \"CRM_Campaign_Info\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Case_Info",
+        "message": "Method \"CRM_Core_Component_Info::getReferenceCounts()\" might add \"array\" as a native return type declaration in the future. Do the same in child class \"CRM_Case_Info\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contact_ActionMapping",
+        "message": "Method \"Civi\\ActionSchedule\\MappingInterface::getId()\" might add \"string|int\" as a native return type declaration in the future. Do the same in implementation \"CRM_Contact_ActionMapping\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Cxn_CiviCxnStore",
+        "message": "Method \"Civi\\Cxn\\Rpc\\CxnStore\\CxnStoreInterface::getAll()\" might add \"array\" as a native return type declaration in the future. Do the same in implementation \"CRM_Cxn_CiviCxnStore\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Cxn_CiviCxnStore",
+        "message": "Method \"Civi\\Cxn\\Rpc\\CxnStore\\CxnStoreInterface::getByCxnId()\" might add \"?array\" as a native return type declaration in the future. Do the same in implementation \"CRM_Cxn_CiviCxnStore\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Cxn_CiviCxnStore",
+        "message": "Method \"Civi\\Cxn\\Rpc\\CxnStore\\CxnStoreInterface::getByAppId()\" might add \"?array\" as a native return type declaration in the future. Do the same in implementation \"CRM_Cxn_CiviCxnStore\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "HTML_QuickForm_Page",
+        "message": "Method \"HTML_QuickForm::exportValues()\" might add \"array\" as a native return type declaration in the future. Do the same in child class \"HTML_QuickForm_Page\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Logging_ReportDetail",
+        "message": "Method \"CRM_Report_Form::buildQuery()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Logging_ReportDetail\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Logging_ReportDetail",
+        "message": "Method \"CRM_Report_Form::limit()\" might add \"array\" as a native return type declaration in the future. Do the same in child class \"CRM_Logging_ReportDetail\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_ActionTokens",
+        "message": "Method \"Civi\\Token\\AbstractTokenSubscriber::checkActive()\" might add \"bool\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_ActionTokens\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_Tokens",
+        "message": "Method \"Civi\\Token\\AbstractTokenSubscriber::checkActive()\" might add \"bool\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_Tokens\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Member_ActionMapping",
+        "message": "Method \"Civi\\ActionSchedule\\MappingInterface::getId()\" might add \"string|int\" as a native return type declaration in the future. Do the same in implementation \"CRM_Member_ActionMapping\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_ACL_DAO_ACLCache",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_ACL_DAO_ACLCache\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_PrintLabel",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_PrintLabel\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_Payment_Dummy",
+        "message": "Method \"CRM_Core_Payment::doRefund()\" might add \"array\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_Payment_Dummy\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_Payment_Manual",
+        "message": "Method \"CRM_Core_Payment::checkConfig()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_Payment_Manual\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_Payment_Manual",
+        "message": "Method \"CRM_Core_Payment::supportsNoEmailProvided()\" might add \"bool\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_Payment_Manual\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_Permission_DrupalBase",
+        "message": "Method \"CRM_Core_Permission_Base::isModulePermissionSupported()\" might add \"bool\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_Permission_DrupalBase\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_Permission_Backdrop",
+        "message": "Method \"CRM_Core_Permission_Base::getAvailablePermissions()\" might add \"array\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_Permission_Backdrop\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_Permission_Backdrop",
+        "message": "Method \"CRM_Core_Permission_Base::isModulePermissionSupported()\" might add \"bool\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_Permission_Backdrop\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_Permission_Drupal",
+        "message": "Method \"CRM_Core_Permission_Base::getAvailablePermissions()\" might add \"array\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_Permission_Drupal\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_Permission_Drupal",
+        "message": "Method \"CRM_Core_Permission_Base::isModulePermissionSupported()\" might add \"bool\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_Permission_Drupal\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_Permission_Joomla",
+        "message": "Method \"CRM_Core_Permission_Base::isModulePermissionSupported()\" might add \"bool\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_Permission_Joomla\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_Permission_WordPress",
+        "message": "Method \"CRM_Core_Permission_Base::getAvailablePermissions()\" might add \"array\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_Permission_WordPress\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_Permission_WordPress",
+        "message": "Method \"CRM_Core_Permission_Base::isModulePermissionSupported()\" might add \"bool\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_Permission_WordPress\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_PrevNextCache_Redis",
+        "message": "Method \"CRM_Core_PrevNextCache_Interface::fillWithSql()\" might add \"bool\" as a native return type declaration in the future. Do the same in implementation \"CRM_Core_PrevNextCache_Redis\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_PrevNextCache_Redis",
+        "message": "Method \"CRM_Core_PrevNextCache_Interface::fillWithArray()\" might add \"bool\" as a native return type declaration in the future. Do the same in implementation \"CRM_Core_PrevNextCache_Redis\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_PrevNextCache_Redis",
+        "message": "Method \"CRM_Core_PrevNextCache_Interface::fetch()\" might add \"array\" as a native return type declaration in the future. Do the same in implementation \"CRM_Core_PrevNextCache_Redis\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_PrevNextCache_Redis",
+        "message": "Method \"CRM_Core_PrevNextCache_Interface::getSelection()\" might add \"?array\" as a native return type declaration in the future. Do the same in implementation \"CRM_Core_PrevNextCache_Redis\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_PrevNextCache_Redis",
+        "message": "Method \"CRM_Core_PrevNextCache_Interface::getPositions()\" might add \"array\" as a native return type declaration in the future. Do the same in implementation \"CRM_Core_PrevNextCache_Redis\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_PrevNextCache_Redis",
+        "message": "Method \"CRM_Core_PrevNextCache_Interface::getCount()\" might add \"int\" as a native return type declaration in the future. Do the same in implementation \"CRM_Core_PrevNextCache_Redis\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_PrevNextCache_Sql",
+        "message": "Method \"CRM_Core_PrevNextCache_Interface::fillWithArray()\" might add \"bool\" as a native return type declaration in the future. Do the same in implementation \"CRM_Core_PrevNextCache_Sql\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Dedupe_BAO_Rule",
+        "message": "The \"CRM_Dedupe_BAO_DedupeRule::validateContacts()\" method is considered internal do not call from outside tested core code. No universe uses Feb 2024. It may change without further notice. You should not extend it from \"CRM_Dedupe_BAO_Rule\".",
+        "count": 1
+    },
+    {
+        "location": "CRM_Dedupe_BAO_Rule",
+        "message": "The \"CRM_Dedupe_BAO_DedupeRule::dedupeRuleFields()\" method is considered internal do not call from outside tested core code. No universe uses Feb 2024. It may change without further notice. You should not extend it from \"CRM_Dedupe_BAO_Rule\".",
+        "count": 1
+    },
+    {
+        "location": "CRM_Event_ActionMapping_ByEvent",
+        "message": "Method \"Civi\\ActionSchedule\\MappingInterface::getId()\" might add \"string|int\" as a native return type declaration in the future. Do the same in implementation \"CRM_Event_ActionMapping_ByEvent\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Event_ActionMapping_ByTemplate",
+        "message": "Method \"Civi\\ActionSchedule\\MappingInterface::getId()\" might add \"string|int\" as a native return type declaration in the future. Do the same in implementation \"CRM_Event_ActionMapping_ByTemplate\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Event_ActionMapping_ByType",
+        "message": "Method \"Civi\\ActionSchedule\\MappingInterface::getId()\" might add \"string|int\" as a native return type declaration in the future. Do the same in implementation \"CRM_Event_ActionMapping_ByType\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_Service_ListUnsubscribe",
+        "message": "Method \"Symfony\\Component\\EventDispatcher\\EventSubscriberInterface::getSubscribedEvents()\" might add \"array\" as a native return type declaration in the future. Do the same in implementation \"CRM_Mailing_Service_ListUnsubscribe\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Queue_Queue_SqlParallel",
+        "message": "Method \"CRM_Queue_Queue::claimItem()\" might add \"object\" as a native return type declaration in the future. Do the same in child class \"CRM_Queue_Queue_SqlParallel\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Activity_Import_Parser_Activity",
+        "message": "Method \"CRM_Import_Parser::init()\" might add \"void\" as a native return type declaration in the future. Do the same in child class \"CRM_Activity_Import_Parser_Activity\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contact_Import_Parser_Contact",
+        "message": "Method \"CRM_Import_Parser::init()\" might add \"void\" as a native return type declaration in the future. Do the same in child class \"CRM_Contact_Import_Parser_Contact\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contribute_Import_Parser_Contribution",
+        "message": "Method \"CRM_Import_Parser::init()\" might add \"void\" as a native return type declaration in the future. Do the same in child class \"CRM_Contribute_Import_Parser_Contribution\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Event_Import_Parser_Participant",
+        "message": "Method \"CRM_Import_Parser::init()\" might add \"void\" as a native return type declaration in the future. Do the same in child class \"CRM_Event_Import_Parser_Participant\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Financial_BAO_ExportFormat_CSV",
+        "message": "Method \"CRM_Financial_BAO_ExportFormat::export()\" might add \"mixed\" as a native return type declaration in the future. Do the same in child class \"CRM_Financial_BAO_ExportFormat_CSV\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Financial_BAO_ExportFormat_IIF",
+        "message": "Method \"CRM_Financial_BAO_ExportFormat::export()\" might add \"mixed\" as a native return type declaration in the future. Do the same in child class \"CRM_Financial_BAO_ExportFormat_IIF\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "Civi\\Core\\MetadataFlush",
+        "message": "Method \"Symfony\\Component\\EventDispatcher\\EventSubscriberInterface::getSubscribedEvents()\" might add \"array\" as a native return type declaration in the future. Do the same in implementation \"Civi\\Core\\MetadataFlush\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "Civi\\Core\\Url",
+        "message": "Method \"JsonSerializable::jsonSerialize()\" might add \"mixed\" as a native return type declaration in the future. Do the same in implementation \"Civi\\Core\\Url\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "Civi\\Managed\\MultisiteManaged",
+        "message": "Method \"Symfony\\Component\\EventDispatcher\\EventSubscriberInterface::getSubscribedEvents()\" might add \"array\" as a native return type declaration in the future. Do the same in implementation \"Civi\\Managed\\MultisiteManaged\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "Civi\\Token\\ImpliedContextSubscriber",
+        "message": "Method \"Symfony\\Component\\EventDispatcher\\EventSubscriberInterface::getSubscribedEvents()\" might add \"array\" as a native return type declaration in the future. Do the same in implementation \"Civi\\Token\\ImpliedContextSubscriber\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "Civi\\WorkflowMessage\\TestBanner",
+        "message": "Method \"Symfony\\Component\\EventDispatcher\\EventSubscriberInterface::getSubscribedEvents()\" might add \"array\" as a native return type declaration in the future. Do the same in implementation \"Civi\\WorkflowMessage\\TestBanner\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "Civi\\Api4\\Generic\\AbstractAction",
+        "message": "Method \"ArrayAccess::offsetGet()\" might add \"mixed\" as a native return type declaration in the future. Do the same in implementation \"Civi\\Api4\\Generic\\AbstractAction\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "Civi\\Api4\\Service\\Autocomplete\\EventAutocompleteProvider",
+        "message": "Method \"Symfony\\Component\\EventDispatcher\\EventSubscriberInterface::getSubscribedEvents()\" might add \"array\" as a native return type declaration in the future. Do the same in implementation \"Civi\\Api4\\Service\\Autocomplete\\EventAutocompleteProvider\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "Civi\\Api4\\Service\\Spec\\RequestSpec",
+        "message": "Method \"Iterator::rewind()\" might add \"void\" as a native return type declaration in the future. Do the same in implementation \"Civi\\Api4\\Service\\Spec\\RequestSpec\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "Civi\\Api4\\Service\\Spec\\RequestSpec",
+        "message": "Method \"Iterator::current()\" might add \"mixed\" as a native return type declaration in the future. Do the same in implementation \"Civi\\Api4\\Service\\Spec\\RequestSpec\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "Civi\\Api4\\Service\\Spec\\RequestSpec",
+        "message": "Method \"Iterator::key()\" might add \"mixed\" as a native return type declaration in the future. Do the same in implementation \"Civi\\Api4\\Service\\Spec\\RequestSpec\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "Civi\\Api4\\Service\\Spec\\SpecGatherer",
+        "message": "Method \"Symfony\\Component\\EventDispatcher\\EventSubscriberInterface::getSubscribedEvents()\" might add \"array\" as a native return type declaration in the future. Do the same in implementation \"Civi\\Api4\\Service\\Spec\\SpecGatherer\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Extension_Upgrader_Base",
+        "message": "Method \"CRM_Extension_Upgrader_Interface::notify()\" might add \"mixed\" as a native return type declaration in the future. Do the same in implementation \"CRM_Extension_Upgrader_Base\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_API_AbstractFieldCoder",
+        "message": "Method \"API_Wrapper::fromApiInput()\" might add \"array\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_API_AbstractFieldCoder\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_API_AbstractFieldCoder",
+        "message": "Method \"API_Wrapper::toApiOutput()\" might add \"array\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_API_AbstractFieldCoder\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_API_HTMLInputCoder",
+        "message": "Method \"CRM_Utils_API_AbstractFieldCoder::decodeOutput()\" might add \"mixed\" as a native return type declaration in the future. Do the same in child class \"CRM_Utils_API_HTMLInputCoder\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_API_NullOutputCoder",
+        "message": "Method \"CRM_Utils_API_AbstractFieldCoder::decodeOutput()\" might add \"mixed\" as a native return type declaration in the future. Do the same in child class \"CRM_Utils_API_NullOutputCoder\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_API_ReloadOption",
+        "message": "Method \"API_Wrapper::fromApiInput()\" might add \"array\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_API_ReloadOption\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_API_ReloadOption",
+        "message": "Method \"API_Wrapper::toApiOutput()\" might add \"array\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_API_ReloadOption\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_API_MatchOption",
+        "message": "Method \"API_Wrapper::fromApiInput()\" might add \"array\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_API_MatchOption\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_API_MatchOption",
+        "message": "Method \"API_Wrapper::toApiOutput()\" might add \"array\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_API_MatchOption\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_DAO_BounceType",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_DAO_BounceType\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_EntityFile",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_EntityFile\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_JobLog",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_JobLog\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_LocBlock",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_LocBlock\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_MappingField",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_MappingField\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_StateProvince",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_StateProvince\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Worldregion",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Worldregion\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contribute_DAO_ContributionProduct",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contribute_DAO_ContributionProduct\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Financial_DAO_PaymentToken",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Financial_DAO_PaymentToken\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contribute_DAO_PremiumsProduct",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contribute_DAO_PremiumsProduct\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Price_DAO_PriceSetEntity",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Price_DAO_PriceSetEntity\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Mailing_DAO_MailingGroup",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Mailing_DAO_MailingGroup\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_LazyArray",
+        "message": "Method \"ArrayAccess::offsetGet()\" might add \"mixed\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_LazyArray\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Utils_LazyArray",
+        "message": "Method \"IteratorAggregate::getIterator()\" might add \"\\Traversable\" as a native return type declaration in the future. Do the same in implementation \"CRM_Utils_LazyArray\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Component",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Component\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_AddressFormat",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_AddressFormat\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_SystemLog",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_SystemLog\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Contact_DAO_ACLContactCache",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Contact_DAO_ACLContactCache\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Financial_DAO_Currency",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Financial_DAO_Currency\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Campaign_DAO_CampaignGroup",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Campaign_DAO_CampaignGroup\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Event_Cart_DAO_Cart",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Event_Cart_DAO_Cart\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Menu",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Menu\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Core_DAO_Timezone",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Core_DAO_Timezone\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Case_DAO_CaseActivity",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Case_DAO_CaseActivity\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Event_Cart_DAO_EventInCart",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Event_Cart_DAO_EventInCart\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "civi\\test\\civitestlistener",
+        "message": "The \"Civi\\Test\\CiviTestListenerPHPUnit7\" class implements \"PHPUnit\\Framework\\TestListener\" that is deprecated.",
+        "count": 1
+    },
+    {
+        "location": "civi\\test\\civitestlistener",
+        "message": "The \"Civi\\Test\\CiviTestListenerPHPUnit7\" class uses \"PHPUnit\\Framework\\TestListenerDefaultImplementation\" that is deprecated The `TestListener` interface is deprecated.",
+        "count": 1
+    },
+    {
+        "location": "HTML_QuickForm_Rule_Email",
+        "message": "Method \"HTML_QuickForm_Rule::getValidationScript()\" might add \"array\" as a native return type declaration in the future. Do the same in child class \"HTML_QuickForm_Rule_Email\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Afform_DAO_AfformSubmission",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Afform_DAO_AfformSubmission\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Search_DAO_SearchDisplay",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Search_DAO_SearchDisplay\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "CRM_Search_DAO_SearchSegment",
+        "message": "Method \"CRM_Core_DAO::getEntityTitle()\" might add \"string\" as a native return type declaration in the future. Do the same in child class \"CRM_Search_DAO_SearchSegment\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    },
+    {
+        "location": "Civi\\Token\\TokenRowIterator",
+        "message": "Method \"IteratorIterator::current()\" might add \"mixed\" as a native return type declaration in the future. Do the same in child class \"Civi\\Token\\TokenRowIterator\" now to avoid errors or add an explicit @return annotation to suppress this message.",
+        "count": 1
+    }
+]

--- a/tests/phpunit/CRM/Moregreetings/CRM_Moregreetings_RendererTest.php
+++ b/tests/phpunit/CRM/Moregreetings/CRM_Moregreetings_RendererTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types = 1);
+
+namespace CRM\Moregreetings;
+
+use Civi\Api4\Contact;
+use Civi\Moregreetings\AbstractMoregreetingsHeadlessTestCase;
+use Civi\Moregreetings\Fixtures\ContactFixture;
+
+/**
+ * @covers \CRM_Moregreetings_Renderer
+ *
+ * @group headless
+ */
+final class CRM_Moregreetings_RendererTest extends AbstractMoregreetingsHeadlessTestCase {
+
+  public function testUpdateMoreGreetings(): void {
+    $contact = ContactFixture::addIndividual(['first_name' => 'Foo', 'last_name' => 'Bar']);
+
+    $template = 'Hello {$contact.first_name} {$contact.last_name}';
+    $templates = ['greeting_smarty_1' => $template];
+    \Civi::settings()->set('moregreetings_templates', $templates);
+    \CRM_Moregreetings_Config::setActiveFieldCount(1);
+
+    \CRM_Moregreetings_Renderer::updateMoreGreetings($contact['id']);
+
+    static::assertSame(
+      'Hello Foo Bar',
+      Contact::get(FALSE)
+        ->addSelect('more_greetings_group.greeting_field_1')
+        ->addWhere('id', '=', $contact['id'])
+        ->execute()->single()['more_greetings_group.greeting_field_1']
+    );
+  }
+
+}

--- a/tests/phpunit/Civi/Moregreetings/AbstractMoregreetingsHeadlessTestCase.php
+++ b/tests/phpunit/Civi/Moregreetings/AbstractMoregreetingsHeadlessTestCase.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types = 1);
+
+namespace Civi\Moregreetings;
+
+use Civi\Test;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
+
+// phpcs:disable Generic.Files.LineLength.TooLong
+abstract class AbstractMoregreetingsHeadlessTestCase extends TestCase implements HeadlessInterface, TransactionalInterface {
+// phpcs:enable
+  public function setUpHeadless(): CiviEnvBuilder {
+    return Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->setUserPermissions(['access CiviCRM']);
+  }
+
+  /**
+   * @phpstan-param array<string>|null $permissions
+   */
+  protected function setUserPermissions(?array $permissions): void {
+    $userPermissions = \CRM_Core_Config::singleton()->userPermissionClass;
+    // @phpstan-ignore-next-line
+    $userPermissions->permissions = $permissions;
+  }
+
+}

--- a/tests/phpunit/Civi/Moregreetings/Fixtures/ContactFixture.php
+++ b/tests/phpunit/Civi/Moregreetings/Fixtures/ContactFixture.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types = 1);
+
+namespace Civi\Moregreetings\Fixtures;
+
+use Civi\Api4\Contact;
+
+final class ContactFixture {
+
+  /**
+   * @param array<string, scalar> $values
+   *
+   * @return array
+   * @phpstan-return array<string, mixed>
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public static function addIndividual(array $values = []): array {
+    return Contact::create(FALSE)
+      ->setValues($values + [
+        'contact_type' => 'Individual',
+        'first_name' => 'Some',
+        'last_name' => 'Individual',
+      ])->execute()->single();
+  }
+
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types = 1);
+
+use Composer\Autoload\ClassLoader;
+
+ini_set('memory_limit', '2G');
+
+if (file_exists(__DIR__ . '/../../vendor/autoload.php')) {
+  require_once __DIR__ . '/../../vendor/autoload.php';
+}
+
+// Make CRM_Moregreetings_ExtensionUtil available.
+require_once __DIR__ . '/../../moregreetings.civix.php';
+
+// phpcs:disable
+eval(cv('php:boot --level=classloader', 'phpcode'));
+// phpcs:enable
+
+// phpcs:disable PSR1.Files.SideEffects
+
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new ClassLoader();
+$loader->add('CRM_', [__DIR__ . '/../..', __DIR__]);
+$loader->addPsr4('Civi\\', [__DIR__ . '/../../Civi', __DIR__ . '/Civi']);
+$loader->add('api_', [__DIR__ . '/../..', __DIR__]);
+$loader->addPsr4('api\\', [__DIR__ . '/../../api', __DIR__ . '/api']);
+$loader->register();
+
+// Ensure function ts() is available - it's declared in the same file as CRM_Core_I18n
+\CRM_Core_I18n::singleton();
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return mixed
+ *   Response output (if the command executed normally).
+ *   For 'raw' or 'phpcode', this will be a string. For 'json', it could be any JSON value.
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv(string $cmd, string $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => STDERR];
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv('CV_OUTPUT=json');
+
+  // Execute `cv` in the original folder. This is a work-around for
+  // phpunit/codeception, which seem to manipulate PWD.
+  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== '/*BEGINPHP*/' || substr(trim($result), -10) !== '/*ENDPHP*/') {
+        throw new RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, TRUE);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}

--- a/tools/phpcs/composer.json
+++ b/tools/phpcs/composer.json
@@ -1,0 +1,11 @@
+{
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/civicrm/coder.git"
+    }
+  ],
+  "require": {
+    "drupal/coder": "dev-8.x-2.x-civi"
+  }
+}

--- a/tools/phpstan/composer.json
+++ b/tools/phpstan/composer.json
@@ -1,0 +1,18 @@
+{
+    "require": {
+        "phpstan/extension-installer": "^1.1",
+        "phpstan/phpstan": "^1.7",
+        "phpstan/phpstan-deprecation-rules": "^1.0",
+        "phpstan/phpstan-phpunit": "^1.1",
+        "phpstan/phpstan-strict-rules": "^1.2",
+        "phpstan/phpstan-webmozart-assert": "^1.2",
+        "thecodingmachine/phpstan-strict-rules": "^1.0",
+        "voku/phpstan-rules": "^3"
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        },
+        "sort-packages": true
+    }
+}

--- a/tools/phpunit/composer.json
+++ b/tools/phpunit/composer.json
@@ -1,0 +1,13 @@
+{
+    "require": {
+        "symfony/phpunit-bridge": "^7"
+    },
+    "scripts": {
+        "post-install-cmd": [
+            "@php vendor/bin/simple-phpunit install --configuration ../../phpunit.xml.dist"
+        ],
+        "post-update-cmd": [
+            "@php vendor/bin/simple-phpunit install --configuration ../../phpunit.xml.dist"
+        ]
+    }
+}


### PR DESCRIPTION
Additionally add configuration for phpcs, phpstan, and phpunit and a first test.

For now phpcs and phpstan only analyse `tests`. This should be changed, though.

systopia-reference: 24737